### PR TITLE
Fix prefix methods for case insensitive tries

### DIFF
--- a/Classes/NDTrie.m
+++ b/Classes/NDTrie.m
@@ -66,16 +66,16 @@ static BOOL getObjectsFunc( id, void * );
 
 static NSUInteger keyComponentCaseInsensitiveForString( id anObject, NSUInteger anIndex, BOOL * anEnd )
 {
-	if( anIndex < [anObject length] )
-	{
-		NSUInteger	theResult = [anObject characterAtIndex:anIndex];
-		if( theResult >= 'a' && theResult <= 'z' )
-			theResult = theResult + 'A' - 'a';
-		return theResult;
-	}
-
-	*anEnd = YES;
-	return 0;
+    NSUInteger		theResult = 0,
+    theLength = [anObject length];
+    if( anIndex < theLength ) {
+        theResult = [anObject characterAtIndex:anIndex];
+        if( theResult >= 'a' && theResult <= 'z' )
+            theResult = theResult + 'A' - 'a';
+    }
+    
+    *anEnd = (anIndex + 1) == theLength;
+    return theResult;
 }
 
 static NSUInteger keyComponentForString( id anObject, NSUInteger anIndex, BOOL * anEnd )

--- a/main.m
+++ b/main.m
@@ -4,7 +4,7 @@
 static NSString		* const kSampleFile = @"/Users/nathan/Developer/Projects/Libraries/ndtrie/sample_file_xml.plist";
 static NSString		* const kUNIXWordsFilePath = @"/usr/share/dict/words";
 
-static void testSetOne();
+static void testSetOneCaseInsensitive(BOOL caseInsensitive);
 static void testRemoveKeyHasNoChildren(BOOL aSolo);
 static void testRemoveKeyHasChildren(BOOL aSolo);
 static void testEveryWord();
@@ -13,7 +13,8 @@ int main (int argc, const char * argv[])
 {
 	@autoreleasepool
 	{
-		testSetOne();
+        testSetOneCaseInsensitive(NO);
+        testSetOneCaseInsensitive(YES);
 		testRemoveKeyHasNoChildren(YES);
 		testRemoveKeyHasNoChildren(NO);
 		testRemoveKeyHasChildren(YES);
@@ -24,13 +25,13 @@ int main (int argc, const char * argv[])
 	return 0;
 }
 
-void testSetOne()
+void testSetOneCaseInsensitive(BOOL caseInsensitive)
 {
 	NSArray				* theTestTrueStrings = @[@"caterpillar", @"dog", @"catalog", @"creak", @"cat", @"caterpillar", @"camera", @"camcorder"],
 						* theTestFalseStrings = @[@"caterpillars", @"do", @"catalogue", @"creek", @"fat", @"bug", @"photo", @"VCR"];
 	NSArray				* theTempArray = nil;
 
-	NDTrie				* theTrie = [NDTrie trieWithArray:theTestTrueStrings];
+    NDTrie* theTrie = [[NDTrie alloc] initWithCaseInsensitive:caseInsensitive array:theTestTrueStrings];
 	NSLog( @"\n%@", theTrie );
 
 	NSCAssert( theTrie.count == 7, @"The Trie had %lu strings", theTrie.count );


### PR DESCRIPTION
Updated `keyComponentCaseInsensitiveForString()` to match `keyComponentForString()` following the fix in issue #6.  

Also updated the test driver in main.m to test case insensitive tries as well as regular ones.
